### PR TITLE
Revert "[.rubocop.yml] disable Style/OptionalBooleanParameter (cause …

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,6 @@ Metrics:
 Style/Documentation:
   Enabled: false
 
-Style/OptionalBooleanParameter:
-  Enabled: false
-
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 


### PR DESCRIPTION
…method in standard library doesn't follow this rule...)"

This reverts commit 2eee85569c3aa0b435e36429b596e4f6586164de.